### PR TITLE
Various fixes, unit tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "illuminate/support": "4.*,
+        "illuminate/support": "4.*",
         "illuminate/config": "4.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "illuminate/support": "4.1.x"
+        "illuminate/support": "4.1.x",
+        "illuminate/config": "4.1.x"
     },
     "autoload": {
         "classmap": [
@@ -22,6 +23,10 @@
         "psr-0": {
             "Queiroz\\WhmcsApi": "src/"
         }
+    },
+    "require-dev": {
+        "mockery/mockery": "0.9.*",
+        "phpunit/phpunit": "3.7.*"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
+        "ext-curl": "*",
         "illuminate/support": "4.1.x"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "illuminate/support": "4.1.x",
-        "illuminate/config": "4.1.x"
+        "illuminate/support": "4.*,
+        "illuminate/config": "4.*"
     },
     "autoload": {
         "classmap": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         syntaxCheck="false"
+>
+    <testsuites>
+        <testsuite name="Package Test Suite">
+            <directory suffix=".php">./tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Queiroz/WhmcsApi/ConnectionException.php
+++ b/src/Queiroz/WhmcsApi/ConnectionException.php
@@ -1,0 +1,3 @@
+<?php namespace Queiroz\WhmcsApi;
+
+class ConnectionException extends \Exception {}

--- a/src/Queiroz/WhmcsApi/WhmcsApi.php
+++ b/src/Queiroz/WhmcsApi/WhmcsApi.php
@@ -1,7 +1,6 @@
 <?php namespace Queiroz\WhmcsApi;
 
 use Config;
-use SimpleXMLElement;
 use stdClass;
 use Illuminate\Config\Repository;
 
@@ -22,7 +21,6 @@ class WhmcsApi
 		$params = array();
 		$params['username']     = $this->config->get('whmcs-api::username');
 		$params['password']     = md5($this->config->get('whmcs-api::password'));
-		$params['url']          = $this->config->get('whmcs-api::url');
 		$params['action']       = $action;
 		$params["responsetype"] = "json";
 
@@ -36,12 +34,7 @@ class WhmcsApi
 
 	public function curl($params)
 	{
-		// set url
-		$url = $params['url'];
-		// unset url
-		unset($params['url']);
-
-		$data = $this->curl->request($url, $params);
+		$data = $this->curl->request($this->config->get('whmcs-api::url'), $params);
 		
 		return json_decode($data);
 	}

--- a/src/Queiroz/WhmcsApi/WhmcsApi.php
+++ b/src/Queiroz/WhmcsApi/WhmcsApi.php
@@ -7,10 +7,10 @@ class WhmcsApi
 	{
 
 		$params = array();
-		$params['username'] 	= \Config::get('whmcs-api::username');
-		$params['password'] 	= md5(\Config::get('whmcs-api::password'));
-		$params['url'] 			= \Config::get('whmcs-api::url');
-		$params['action']		= $action;
+		$params['username']     = \Config::get('whmcs-api::username');
+		$params['password']     = md5(\Config::get('whmcs-api::password'));
+		$params['url']          = \Config::get('whmcs-api::url');
+		$params['action']       = $action;
 
 		// merge $actionParams with $params
 		$params = array_merge($params, $actionParams);
@@ -30,13 +30,13 @@ class WhmcsApi
 		$ch = curl_init();
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_POST, 1);
-		curl_setopt($ch, CURLOPT_TIMEOUT, 100);
+		curl_setopt($ch, CURLOPT_TIMEOUT, 5);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
 		$data = curl_exec($ch);
 
 		if (curl_error($ch)) {
-			throw new \Exception("Connection Error: " . curl_errno($ch) . ' - ' . curl_error($ch));
+			throw new ConnectionException("Connection Error: " . curl_errno($ch) . ' - ' . curl_error($ch));
 		}
 
 		curl_close($ch);
@@ -78,10 +78,12 @@ class WhmcsApi
 
 	public function execute($action, $params)
 	{
-		
-		// Initiate
 		return $this->init($action, $params);
+	}
 
+	public function __call($method, $params)
+	{
+		return $this->execute($action, $params[0]);
 	}
 
 }

--- a/src/Queiroz/WhmcsApi/WhmcsApi.php
+++ b/src/Queiroz/WhmcsApi/WhmcsApi.php
@@ -24,6 +24,7 @@ class WhmcsApi
 		$params['password']     = md5($this->config->get('whmcs-api::password'));
 		$params['url']          = $this->config->get('whmcs-api::url');
 		$params['action']       = $action;
+		$params["responsetype"] = "json";
 
 		// merge $actionParams with $params
 		$params = array_merge($params, $actionParams);
@@ -41,40 +42,8 @@ class WhmcsApi
 		unset($params['url']);
 
 		$data = $this->curl->request($url, $params);
-
-		// Identify XML result
-		$xml = preg_match('/(\<\?xml)/', $data);
 		
-		if($xml) {
-			return $this->formatXml($data);
-		} else {
-			return $this->formatObject($data);
-		}
-
-	}
-
-	public function formatXml($input)
-	{
-		return new SimpleXMLElement($input);
-	}
-
-	public function formatObject($input)
-	{
-
-		$results = explode(';' ,$input);
-
-		$object = new stdClass(); // standard object
-
-		foreach($results as $result) {
-
-			if(!empty($result)) {
-				$resultValue = explode('=', $result);
-				$object->$resultValue[0] = $resultValue[1];
-			}
-
-		}
-
-		return $object;
+		return json_decode($data);
 	}
 
 	public function execute($action, $params)

--- a/src/Queiroz/WhmcsApi/WhmcsApi.php
+++ b/src/Queiroz/WhmcsApi/WhmcsApi.php
@@ -27,7 +27,7 @@ class WhmcsApi
 		$params["responsetype"] = "json";
 
 		// merge $actionParams with $params
-		$params = array_merge($params, $actionParams);
+		$params = array_merge($actionParams, $params);
 
 		// call curl init connection
 		return $this->curl($params);

--- a/src/Queiroz/WhmcsApi/WhmcsApiServiceProvider.php
+++ b/src/Queiroz/WhmcsApi/WhmcsApiServiceProvider.php
@@ -19,6 +19,8 @@ class WhmcsApiServiceProvider extends ServiceProvider {
 	public function boot()
 	{
 		$this->package('queiroz/whmcs-api');
+
+		$app = $this->app;
 	}
 
 	/**
@@ -29,9 +31,9 @@ class WhmcsApiServiceProvider extends ServiceProvider {
 	public function register()
 	{
 
-		$this->app['WhmcsApi'] = $this->app->share(function() {
+		$this->app['WhmcsApi'] = $this->app->share(function($app) {
 			
-			return new WhmcsApi();
+			return new WhmcsApi($app['config'], new WhmcsCurl);
 
 		});
 

--- a/src/Queiroz/WhmcsApi/WhmcsCurl.php
+++ b/src/Queiroz/WhmcsApi/WhmcsCurl.php
@@ -6,8 +6,9 @@ class WhmcsCurl
     {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_SAFE_UPLOAD, true);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
         $data = curl_exec($ch);
 

--- a/src/Queiroz/WhmcsApi/WhmcsCurl.php
+++ b/src/Queiroz/WhmcsApi/WhmcsCurl.php
@@ -7,7 +7,6 @@ class WhmcsCurl
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 5);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
         $data = curl_exec($ch);

--- a/src/Queiroz/WhmcsApi/WhmcsCurl.php
+++ b/src/Queiroz/WhmcsApi/WhmcsCurl.php
@@ -1,0 +1,23 @@
+<?php namespace Queiroz\WhmcsApi;
+
+class WhmcsCurl
+{
+    public function request($url, $params)
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+        $data = curl_exec($ch);
+
+        if (curl_error($ch)) {
+            throw new ConnectionException("Connection Error: " . curl_errno($ch) . ' - ' . curl_error($ch));
+        }
+
+        curl_close($ch);
+
+        return $data;
+    }
+}


### PR DESCRIPTION
- Fixed some formatting issues in the code
- Magic method, so you can call `Whmcs::action(array(/* parameters... */));`
- Throw a specific exception, rather than a generic Exception, on a Curl failure
- Specify that Curl is required within the composer.json
- Added unit tests, 100% coverage outside the service provider
